### PR TITLE
MAR-4787: change VulnerItem from div onClick to href tag + remove ext…

### DIFF
--- a/src/components/VulnerListItem.vue
+++ b/src/components/VulnerListItem.vue
@@ -1,11 +1,12 @@
 <template>
   <li>
-    <div
+    <a
       class="flex cursor-pointer flex-col sm:flex-row sm:justify-between sm:items-end gap-2 sm:gap-3 pb-4 mb-4 border-b-2 border-gray-400"
-      @click="handleSingleVulItemClick($event)"
       data-gac="CTA Links"
       :data-gaa="vul.title"
       :data-gal="vul.path"
+      :href="vul.path"
+
     >
       <div class="left">
         <div class="xray-id text-sm">{{vul.xray_id}}</div>
@@ -14,14 +15,15 @@
           <span :class="`badge hidden sm:block font-bold flex items-center justify-center bg-${severityColorVal} px-2 py-1 uppercase text-white`">{{vul.severity}}</span>
           <span class="vul-id hidden sm:block text-xs font-bold sm:hidden text-jfrog-green underline">{{vul.vul_id}}</span>
         </div>
-        <div
-          class="vul-id text-xs font-bold mt-1 hidden sm:block text-jfrog-green underline"
+        <a
+            :href="vul.path"
+            class="vul-id text-xs font-bold mt-1 hidden sm:block text-jfrog-green underline"
           data-gac="CTA Links"
           :data-gaa="vul.title"
-          :data-gal="`${vul.vul_id} | ${url}`"
+          :data-gal="`${vul.vul_id} | ${vul.path}`"
         >
           {{vul.vul_id}}
-        </div>
+        </a>
       </div>
 
       <div class="sm:hidden 123 flex gap-3 items-center">
@@ -41,7 +43,7 @@
           <span class="text-jfrog-green hidden sm:block">&#x25cf;</span>
         </div>
       </div>
-    </div>
+    </a>
   </li>
 </template>
 
@@ -68,7 +70,8 @@ export default {
   },
   data() {
     return {
-      url: `https://nvd.nist.gov/vuln/detail/${this.vul.vul_id}`
+      // url: `https://nvd.nist.gov/vuln/detail/${this.vul.vul_id}`
+      url: this.vul.path
     }
   },
   computed: {
@@ -83,16 +86,16 @@ export default {
   methods: {
     goToVulURL() {
       // const url = `https://nvd.nist.gov/vuln/detail/${this.vul.vul_id}`
-      window.open(this.url, '_blank').focus();
+      // window.open(this.url, '_blank').focus();
     },
-    handleSingleVulItemClick(event) {
-      const t = event.target
-      if (t.classList.contains('vul-id')) {
-        this.goToVulURL()
-      } else {
-        this.$router.push({ path: this.vul.path })
-      }
-    }
+    // handleSingleVulItemClick(event) {
+    //   const t = event.target
+    //   if (t.classList.contains('vul-id')) {
+    //     // this.goToVulURL()
+    //   } else {
+    //     this.$router.push({ path: this.vul.path })
+    //   }
+    // }
   }
 }
 </script>


### PR DESCRIPTION
Change VulnerItem from div tag onClick to  a href .
Currently, the links are in JS, which makes them nonindexable - this creates a situation with no internal links to specific CVE pages.
Also remove external links to https://nvd.nist.gov/ from this pages  